### PR TITLE
Bugfix for start-up animation and font size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -254,8 +254,18 @@ html body .show01 .tile .inner:after {
 }
 #digits #zero { position: absolute; left: 0; top: 0; width: 50%; height: 100%;}
 #digits #one { position: absolute; right: 0; top: 0; width: 50%; height: 100%;}
-#digits #hs { 
-  color: #fff; padding-left: 3%;
+#digits #hs1 { 
+  color: #fff; padding-left: 36%;
+  font-size: 40px;
+  text-shadow: 0 0 10px transparent;
+  -webkit-transition: color 1s ease-out;
+  -moz-transition: color 1s ease-out;
+  -ms-transition: color 1s ease-out;
+  transition: all 1s ease-out;
+}
+#digits #hs2 { 
+  color: #fff; padding-left: 40%;
+  font-size: 40px;
   text-shadow: 0 0 10px transparent;
   -webkit-transition: color 1s ease-out;
   -moz-transition: color 1s ease-out;
@@ -272,14 +282,20 @@ html body .show01 .tile .inner:after {
 }
 .hide0 #digits #zero { color: transparent; }
 .hide1 #digits #one { color: transparent; }
-.hidehs #digits #hs { 
+.hidehs #digits #hs1 { 
   color: transparent; 
   -webkit-transition: color .1s ease-out;
   -moz-transition: color .1s ease-out;
   -ms-transition: color .1s ease-out;
   transition: color .1s ease-out;
 }
-
+.hidehs #digits #hs2 { 
+  color: transparent; 
+  -webkit-transition: color .1s ease-out;
+  -moz-transition: color .1s ease-out;
+  -ms-transition: color .1s ease-out;
+  transition: color .1s ease-out;
+}
 
 .tile.marked .inner { 
   border: solid #fff 3px; 

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
                 <h2>OhSteem</h2>
                 <div id="titlegrid" class="board">
                     <div id="digits">                    
-                        <span id="zero">O</span><span id="hs"> h </span><span id="one">S</span><span id="hs"> teem </span>
+                        <span id="zero">O</span><span id="hs1">h</span><span id="one">S</span><span id="hs2">teem </span>
                     </div>
 <table data-grid="titlegrid" cellpadding="0" cellspacing="0"><tbody><tr><td class="odd"><div class="tile tile-2"><div class="inner"></div></div></td><td class="even"><div class="tile tile-1"><div class="inner"></div></td></tr></tbody></table>
 

--- a/js/game.js
+++ b/js/game.js
@@ -55,7 +55,7 @@ var Game = new (function() {
     showTitleScreen();
     resize();
     
-    var colors = ['#a7327c', '#c24b31', '#c0cd31']
+    var colors = ['#a7327c', '#00eeb7', '#c0cd31']
     Utils.setColorScheme(colors[1]);
   }
 

--- a/js/game.js
+++ b/js/game.js
@@ -96,10 +96,10 @@ var Game = new (function() {
 
     var containerSize = box.width;
 
-    $('h1').css('font-size', Math.round(containerSize * .24) + 'px')
-    $('h2').css('font-size', Math.round(containerSize * .18) + 'px')
-    $('h3').css('font-size', Math.round(containerSize * .15) + 'px')
-    $('p').css('font-size', Math.round(containerSize * .07) + 'px')
+    $('h1').css('font-size', Math.round(containerSize * .22) + 'px')
+    $('h2').css('font-size', Math.round(containerSize * .16) + 'px')
+    $('h3').css('font-size', Math.round(containerSize * .13) + 'px')
+    $('p').css('font-size', Math.round(containerSize * .055) + 'px')
     $('#menu h2').css('font-size', Math.round(containerSize * .24) + 'px')
     $('#menu p').css('font-size', Math.round(containerSize * .1) + 'px')
     $('#menu p').css('padding', Math.round(containerSize * .05) + 'px 0')

--- a/js/utils.js
+++ b/js/utils.js
@@ -263,6 +263,7 @@ var Colors = new (function() {
   }
  
   function getComplementary(rgb) {
+    /*
     var asHex = false;
     if (typeof rgb == 'string')
       asHex = true;
@@ -274,6 +275,8 @@ var Colors = new (function() {
     if (asHex)
       result = rgbToHex(result);
     return result;
+    */
+    return "#1c252b"
   }
 
   function rgbToHsv(rgb) {


### PR DESCRIPTION
Changes:
- `css/style.css` - split the `hs` element into `hs1` and `hs2` to control the sizes of the text for "Oh Steem"
- `index.html` - changed the id for "Oh" text to `hs1`; changed the id for "Steem" to `hs2`
- `js/game.js` - changed box color to teal; changed font sizes;
- `js/utils.js` - directly returned value of `getComplementary` to Midnight blue;

![bugfix](https://user-images.githubusercontent.com/29425738/32955929-5eff70ac-cbf2-11e7-9d71-423ae07df5e2.gif)
